### PR TITLE
Fixed/improved tab display management

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -85,6 +85,7 @@ const config default_cfg = {
   .log = "",
   .utmp = false,
   .title = "",
+  .title_settable = true,
   // "Hidden"
   .app_id = "",
   .col_spacing = 0,
@@ -205,6 +206,7 @@ options[] = {
   {"Icon", OPT_STRING, offcfg(icon)},
   {"Log", OPT_STRING, offcfg(log)},
   {"Title", OPT_STRING, offcfg(title)},
+  {"TitleSettable", OPT_BOOL, offcfg(title_settable)},
   {"Utmp", OPT_BOOL, offcfg(utmp)},
   {"Window", OPT_WINDOW, offcfg(window)},
   {"X", OPT_INT, offcfg(x)},

--- a/src/config.h
+++ b/src/config.h
@@ -100,6 +100,7 @@ typedef struct {
   string icon;
   string log;
   string title;
+  bool title_settable;
   bool utmp;
   char window;
   int x, y;

--- a/src/winmain.c
+++ b/src/winmain.c
@@ -124,6 +124,7 @@ win_restore_title(void)
   wstring title = titles[--titles_i];
   if (title) {
     SetWindowTextW(wnd, title);
+    win_tab_title(win_active_terminal(), (wchar_t *)title);
     delete(title);
     titles[titles_i] = 0;
   }

--- a/src/winpriv.h
+++ b/src/winpriv.h
@@ -60,7 +60,7 @@ bool win_is_fullscreen;
 void win_process_timer_message(WPARAM message);
 
 void win_tab_set_argv(char** argv);
-void win_tab_init(char* home, char* cmd, char** argv, int width, int height);
+void win_tab_init(char* home, char* cmd, char** argv, int width, int height, char* title);
 int win_tab_count();
 int win_active_tab();
 void win_tab_change(int change);


### PR DESCRIPTION
 - Tabs can now have their own title (through -t option set BEFORE the -b option)
   Main window title now correctly switch to tab title when switching tab
 - Main window can have its own title through -T option
   In this case the title is fixed and do not switch to tab title
 - Tabs looks alike well known Windows tab
   tab title is vertically centered
   tab has a maximum width
   there is some additional lines between tabs an terminal
 - In case there are multiple terminals open, an additional request message box is displayed
   if you push the main window close button (do you want to close all the terminal or only the active one?)