### PR TITLE
fix termout.c compile -Werror=misleading-indentation in gcc 6.3.0

### DIFF
--- a/src/termout.c
+++ b/src/termout.c
@@ -1249,9 +1249,10 @@ term_write(struct term* term, const char *buf, uint len)
         }
         else if (c >= '0' && c <= '9') {
           uint i = term->csi_argc - 1;
-          if (i < lengthof(term->csi_argv))
+          if (i < lengthof(term->csi_argv)) {
             term->csi_argv[i] = 10 * term->csi_argv[i] + c - '0';
             term->csi_argv_defined[i] = 1;
+          }
         }
         else if (c < 0x40)
           term->esc_mod = term->esc_mod ? 0xFF : c;


### PR DESCRIPTION
fatty is great tool that I use with msys2 for some time, recently I have updated the gcc version to 6.3.0 and found there is a compile error. After a quick look, I found it can be fixed by simply adding few characters, hope this pull request can help to fix the issue for anyone who wants to use fatty with up-to-date environment.

